### PR TITLE
Add a decision template to the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,10 @@ Copied from [decision-record-template-by-michael-nygard](https://github.com/joel
 
 ## Status
 
-What is the status, such as proposed, accepted, rejected, deprecated, superseded, etc.?
+Which packages adopted the changes based on this decision? 
+
+[Adopted v1](https://github.com/pyiron/decisions/pull/1)
+- https://github.com/pyiron/executorlib/pull/644
 
 ## Context
 
@@ -23,3 +26,22 @@ What is the change that we're proposing and/or doing?
 
 What becomes easier or more difficult to do because of this change?
 ```
+
+# Supported Packages
+The adoption of the following packages is tracked in this repository: 
+
+| Package                                    | Maintainer   |
+|--------------------------------------------|--------------|
+| https://github.com/pyiron/atomistics       | @jan-janssen |
+| https://github.com/pyiron/conda_subprocess | @jan-janssen |
+| https://github.com/pyiron/elaston          | @samwaseda   |
+| https://github.com/pyiron/executorlib      | @jan-janssen |
+| https://github.com/pyiron/pyfileindex      | @jan-janssen |
+| https://github.com/pyiron/pyiron_lammps    | @jan-janssen |
+| https://github.com/pyiron/pyiron_snippets  | @liamhuber   |
+| https://github.com/pyiron/sphinx_parser    | @samwaseda   |
+| https://github.com/pyiron/pyiron_workflow  | @liamhuber   |
+| https://github.com/pyiron/pylammpsmpi      | @jan-janssen |
+| https://github.com/pyiron/pysqa            | @jan-janssen |
+| https://github.com/pyiron/semantikon       | @samwaseda   |
+| https://github.com/pyiron/structuretoolkit | @jan-janssen |

--- a/README.md
+++ b/README.md
@@ -1,3 +1,25 @@
 # `pyiron` project-wide decisions
 
 This repository holds [architecture decision records](https://github.com/joelparkerhenderson/architecture-decision-record) (simply "decisions") that are relevant to writing code project-wide inside `pyiron`.
+
+# Decision Template 
+Copied from [decision-record-template-by-michael-nygard](https://github.com/joelparkerhenderson/architecture-decision-record/tree/main/locales/en/templates/decision-record-template-by-michael-nygard) to simplify the creation of new decisions.
+```
+# Title
+
+## Status
+
+What is the status, such as proposed, accepted, rejected, deprecated, superseded, etc.?
+
+## Context
+
+What is the issue that we're seeing that is motivating this decision or change?
+
+## Decision
+
+What is the change that we're proposing and/or doing?
+
+## Consequences
+
+What becomes easier or more difficult to do because of this change?
+```


### PR DESCRIPTION
To lower the barrier of creating new decision records, I think it is helpful to add a decision template directly to the readme of the repository. 