### PR TITLE
Amend api

### DIFF
--- a/decisions/25-001-split-api.md
+++ b/decisions/25-001-split-api.md
@@ -3,6 +3,7 @@
 ## Status
 
 Proposed
+Amended
 
 ## Context
 

--- a/decisions/25-001-split-api.md
+++ b/decisions/25-001-split-api.md
@@ -5,7 +5,7 @@
 [Adopted](https://github.com/pyiron/decisions/pull/1)
 - https://github.com/pyiron/executorlib/pull/644
 
-[Amended](https://github.com/pyiron/decisions/pull/10)
+[Adopted v2](https://github.com/pyiron/decisions/pull/10)
 - https://github.com/pyiron/executorlib/pull/644
 - https://github.com/pyiron/pyiron_workflow/pull/643
 

--- a/decisions/25-001-split-api.md
+++ b/decisions/25-001-split-api.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-[Adopted](https://github.com/pyiron/decisions/pull/1)
+[Adopted v1](https://github.com/pyiron/decisions/pull/1)
 - https://github.com/pyiron/executorlib/pull/644
 
 [Adopted v2](https://github.com/pyiron/decisions/pull/10)

--- a/decisions/25-001-split-api.md
+++ b/decisions/25-001-split-api.md
@@ -2,8 +2,12 @@
 
 ## Status
 
-Proposed
-Amended
+[Adopted](https://github.com/pyiron/decisions/pull/1)
+- https://github.com/pyiron/executorlib/pull/644
+
+[Amended](https://github.com/pyiron/decisions/pull/10)
+- https://github.com/pyiron/executorlib/pull/644
+- https://github.com/pyiron/pyiron_workflow/pull/643
 
 ## Context
 

--- a/decisions/25-001-split-api.md
+++ b/decisions/25-001-split-api.md
@@ -14,7 +14,7 @@ Proposed
 
 ## Decision
 
-- `pyiron` packages should provide a concise user-facing API directly in the topmost `__init__.py` file; if appropriate for the package, they should provide a second, developer-facing API for power-users of the package under `api.py`.
+- `pyiron` packages should provide a concise user-facing API directly in the topmost `__init__.py` file; if appropriate for the package, they should provide a second API for power-users of the package under `api.py`.
 - Objects included in both these APIs are what we consider for evaluating how to update the semantic versioning of new releases.
 
 ## Consequences

--- a/decisions/25-001-split-api.md
+++ b/decisions/25-001-split-api.md
@@ -14,7 +14,7 @@ Proposed
 
 ## Decision
 
-- `pyiron` packages should provide a concise user-facing API directly in the topmost `__init__.py` file; if appropriate for the package, they should provide a second, disjoint set developer-facing API for power-users of the package under `api.py`.
+- `pyiron` packages should provide a concise user-facing API directly in the topmost `__init__.py` file; if appropriate for the package, they should provide a second, developer-facing API for power-users of the package under `api.py`.
 - Objects included in both these APIs are what we consider for evaluating how to update the semantic versioning of new releases.
 
 ## Consequences
@@ -22,3 +22,4 @@ Proposed
 - Standard users should see a shorter tab-completion list 
 - Power users consistently know where to look for an extended list of tools
 - Users of all types get increased clarity of what is protected by our semantic versioning and what they use at their own risk
+- Package maintainers may (but are not required to) use the `api.py` to manage deprecation cycles from tools exposed in `__init__.py`


### PR DESCRIPTION
- Relaxes the requirement that the APIs be disjoint
- Indicates a possible use-case of overlapping APIs
- Relaxes the language around the intent of the second API