### PR TITLE
Suggest following the Python recommendation for the directory structure

### DIFF
--- a/decisions/25-005-project-structure.md
+++ b/decisions/25-005-project-structure.md
@@ -7,6 +7,7 @@ Adopted in the following pull requests:
 * https://github.com/pyiron/executorlib/pull/846
 * https://github.com/pyiron/pyfileindex/pull/242
 * https://github.com/pyiron/pylammpsmpi/pull/389
+* https://github.com/pyiron/pysqa/pull/469
 
 ## Context
 


### PR DESCRIPTION
Context:
* The official Python documentation provides a [recommendation how to structure a Python package](https://packaging.python.org/en/latest/tutorials/packaging-projects/).
* It recommends to store the Python package in `src/package_name` rather than `package_name` as it is currently done inside the pyiron organisation. 
* By maintaining consistency with the official Python documentation we make the pyiron project more accessible for external developers. 
